### PR TITLE
Fix debug_assert! optimizing away Mutex::drop

### DIFF
--- a/src/rtos/mod.rs
+++ b/src/rtos/mod.rs
@@ -176,7 +176,7 @@ impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
 	fn drop(&mut self) {
-		debug_assert!(self.lock.mutex.give());
+		assert!(self.lock.mutex.give());
 	}
 }
 


### PR DESCRIPTION
Mutexes die in Release builds, changing to `assert!` is least effort fix.